### PR TITLE
added neoloadcsvskelgen to the Import section

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ Neo4j graph database.
 - [neo4j-csv-firehose](https://github.com/sarmbruster/neo4j-csv-firehose) - Enables Neo4j’s `LOAD CSV` Cypher command to load from other datasources as well.
 - [neo4j-rdbms-import](https://github.com/jexp/neo4j-rdbms-import) - An automatic importer for relational databases into Neo4j.
 - [Doc manager for Neo4j](https://github.com/neo4j-contrib/neo4j_doc_manager) - The Neo4j Doc Manager takes MongoDB documents and makes it easy to query them for relationships by making them available in a Neo4j graph structure, following the format specified by Mongo Connector.
+- [neoloadcsvskelgen](https://github.com/wadael/neoloadcsvskelgen) - Will output a skeleton of LOAD CSV Cypher code, from very little input (filename, separator, hints). Save time, avoid typos. 
 
 # Benchmarking
 


### PR DESCRIPTION
Added neoloadcsvskelgen to the Import section.
A procedure that will generate a skeleton of LOAD CSV Cypher script.

Example call:

     CALL wadael.csvskelgen("_FullPath/_guardian_most_polluting_companies_list.csv","|",4,"Company:3")


See https://github.com/wadael/neoloadcsvskelgen for more info